### PR TITLE
Switch back to SrcML for all possible cases

### DIFF
--- a/copy.sh
+++ b/copy.sh
@@ -1,0 +1,7 @@
+#mkdir -p old-joern/projects/extensions/joern-fuzzyc/build/libs
+#mkdir -p old-joern/projects/extensions/jpanlib/build/libs
+#mkdir -p old-joern/projects/octopus/lib
+
+scp old-joern/projects/extensions/joern-fuzzyc/build/libs/joern-fuzzyc.jar benjis@prontodtn.las.iastate.edu:/home/benjis/ReVeal/deployment/ReVeal/cfactor/old-joern/projects/extensions/joern-fuzzyc/build/libs/joern-fuzzyc.jar
+scp old-joern/projects/extensions/jpanlib/build/libs/jpanlib.jar benjis@prontodtn.las.iastate.edu:/home/benjis/ReVeal/deployment/ReVeal/cfactor/old-joern/projects/extensions/jpanlib/build/libs/jpanlib.jar
+scp old-joern/projects/octopus/lib/* benjis@prontodtn.las.iastate.edu:/home/benjis/ReVeal/deployment/ReVeal/cfactor/old-joern/projects/octopus/lib/

--- a/cpg.py
+++ b/cpg.py
@@ -10,7 +10,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-joern_bin = Path('./old-joern/joern-parse')
+joern_bin = Path(__file__).parent / 'old-joern/joern-parse'
 assert joern_bin.exists(), joern_bin
 
 def gather_stmts(nodes):

--- a/cpg.py
+++ b/cpg.py
@@ -29,26 +29,24 @@ def list_files(startpath):
         for f in files:
             logger.debug('{}{}'.format(subindent, f))
 
-def parse(project_dir, filepath, exclude, copy_out=False):
-    dst_filepath = filepath
 
+def parse(filepath):
     # Invoke joern
-    with tempfile.TemporaryDirectory() as joern_parse_dir:
-        joern_parse_dir = Path(joern_parse_dir) / 'parsed'
-        if copy_out:
-            joern_parse_dir.mkdir('tmp')
-            shutil.copy2(filepath, joern_parse_dir)
-        cmd = f'bash {joern_bin} {filepath.parent.absolute()} -outdir {joern_parse_dir.absolute()}'
+    joern_dir = filepath.parent.with_suffix('.parsed')
+    try:
+        cmd = f'bash {joern_bin} {filepath.parent.absolute()} -outdir {joern_dir.absolute()}'
         proc = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         if proc.returncode != 0:
             logger.error(proc.stdout.decode())
 
-        output_path = joern_parse_dir / str(dst_filepath.absolute())[1:]
-        assert output_path.exists()
+        output_path = joern_dir / str(filepath.absolute())[1:]
+        assert output_path.exists(), output_path
         nodes_path = output_path / 'nodes.csv'
         edges_path = output_path / 'edges.csv'
         nodes_df = pd.read_csv(nodes_path, sep='\t')
         edges_df = pd.read_csv(edges_path, sep='\t')
+    finally:
+        shutil.rmtree(joern_dir)
 
     cpg = nx.MultiDiGraph()
     nodes_attributes = [{k:v if not pd.isnull(v) else '' for k, v in dict(row).items()} for i, row in nodes_df.iterrows()]

--- a/refactorings/__init__.py
+++ b/refactorings/__init__.py
@@ -15,7 +15,6 @@ from refactorings.rename_variable import RenameVariable
 from refactorings.permute_stmt import PermuteStmt
 from refactorings.switch_exchange import SwitchExchange
 from refactorings.loop_exchange import LoopExchange
-from refactorings.project import TransformationsFactory
 import sys
 
 all_refactorings = [
@@ -38,6 +37,4 @@ def first_picker(targets, **kwargs):
 debug = False
 if debug:
     print(f'Loaded ({[r.__name__ for r in all_refactorings]})', file=sys.stderr)
-    print(f'Loaded {TransformationsFactory.__name__}', file=sys.stderr)
 
-from .project import TransformationsFactory

--- a/refactorings/base.py
+++ b/refactorings/base.py
@@ -29,9 +29,6 @@ class BaseTransformation(abc.ABC):
     def __init__(self, c_file, **kwargs):
         # Load target source file
         self.c_file = Path(c_file)
-        project = Path(kwargs.get("project", self.c_file.parent))
-        prefix = f'{project}:{self.c_file}'
-        self.logger = PrefixedLoggerAdapter(prefix, self.logger)
 
         with open(self.c_file) as f:
             self.old_lines = f.readlines()
@@ -39,7 +36,7 @@ class BaseTransformation(abc.ABC):
         with open(self.c_file, newline='\r\n') as f:
             self.old_text = f.read()
         if '\r' in self.old_text:
-            raise Exception(f'{c_file} is CRLF')
+            raise Exception(f'CRLF')
             
         self.rng = random.Random(0)
         
@@ -49,12 +46,7 @@ class BaseTransformation(abc.ABC):
         else:
             self.avoid_lineno = set()
 
-        try:
-            exclude_files = kwargs.get("exclude", None)
-            copy_out = kwargs.get("copy_out", False)
-            self.joern = JoernInfo(self.c_file, project, exclude_files, copy_out)
-        except Exception as e:
-            self.logger.exception(e)
+        self.joern = JoernInfo(c_file)
 
     @abc.abstractmethod
     def get_targets(self, target):
@@ -81,8 +73,6 @@ class BaseTransformation(abc.ABC):
     @classmethod
     def get_indent(cls, line):
         return line[:-len(line.lstrip())]
-    def get_location(self, n):
-        return JoernLocation.fromstring(self.joern.node_location[n])
 
     def run(self):
         all_targets = self.get_targets()

--- a/refactorings/base.py
+++ b/refactorings/base.py
@@ -10,6 +10,8 @@ import random
 import traceback
 import logging
 
+from srcml import SrcMLInfo
+
 logger = logging.getLogger(__name__)
 
 
@@ -46,8 +48,6 @@ class BaseTransformation(abc.ABC):
         else:
             self.avoid_lineno = set()
 
-        self.joern = JoernInfo(c_file)
-
     @abc.abstractmethod
     def get_targets(self, target):
         """
@@ -68,6 +68,7 @@ class BaseTransformation(abc.ABC):
         try:
             return self._apply(target)
         except (NotImplementedError, AssertionError) as e:
+            self.handle_exception(e)
             raise BadNodeException(*e.args)
 
     @classmethod
@@ -104,4 +105,16 @@ class BaseTransformation(abc.ABC):
                     continue
                 else:
                     return new_lines
-        return new_lines
+        return
+
+
+class JoernTransformation(BaseTransformation):
+    def __init__(self, c_file, *args, **kwargs):
+        super().__init__(c_file, *args, **kwargs)
+        self.joern = JoernInfo(c_file)
+
+
+class SrcMLTransformation(BaseTransformation):
+    def __init__(self, c_file, *args, **kwargs):
+        super().__init__(c_file, *args, **kwargs)
+        self.srcml = SrcMLInfo(self.old_text)

--- a/refactorings/insert_noop.py
+++ b/refactorings/insert_noop.py
@@ -1,10 +1,10 @@
 """Insert Noop: insert a statement that doesn't affect any other variables."""
 
-from refactorings.base import BaseTransformation
+from refactorings.base import BaseTransformation, JoernTransformation
 from refactorings.random_word import get_random_word, get_random_typename_value
 import string
 
-class InsertNoop(BaseTransformation):
+class InsertNoop(JoernTransformation):
     def get_targets(self):
         def is_target(n):
             is_valid_stmt = self.joern.node_type[n] in ('ExpressionStatement', 'IfStatement', 'ElseStatement', 'ForStatement', 'WhileStatement')

--- a/refactorings/insert_noop_joern.py
+++ b/refactorings/insert_noop_joern.py
@@ -1,0 +1,30 @@
+"""Insert Noop: insert a statement that doesn't affect any other variables."""
+
+from refactorings.base import BaseTransformation, JoernTransformation
+from refactorings.random_word import get_random_word, get_random_typename_value
+import string
+
+class InsertNoopJoernVersion(JoernTransformation):
+    def get_targets(self):
+        def is_target(n):
+            is_valid_stmt = self.joern.node_type[n] in ('ExpressionStatement', 'IfStatement', 'ElseStatement', 'ForStatement', 'WhileStatement')
+            has_valid_location = self.joern.node_location[n] is not None
+            pred = list(self.joern.ast.predecessors(n))
+            if len(pred) > 0:
+                parent_is_compound = self.joern.node_type[pred[0]] == 'CompoundStatement'
+            else:
+                parent_is_compound = False
+            return is_valid_stmt and parent_is_compound and has_valid_location
+        return [self.joern.node_location[n] for n in filter(is_target, self.joern.ast.nodes)]
+
+    def _apply(self, target):
+        target_line = int(target.line)
+        target_idx = target_line - 1
+
+        new_name = get_random_word()
+
+        typename, value = get_random_typename_value()
+
+        indent = self.old_lines[target_idx][:-len(self.old_lines[target_idx].lstrip())]
+        self.old_lines.insert(target_idx, f'{indent}{typename} {new_name} = {value};\n')
+        return self.old_lines

--- a/refactorings/joern.py
+++ b/refactorings/joern.py
@@ -3,8 +3,8 @@ import networkx as nx
 import dataclasses
 
 class JoernInfo:
-    def __init__(self, c_file, project, exclude, copy_out):
-        self.g = cpg.parse(project, c_file, exclude, copy_out)
+    def __init__(self, *args):
+        self.g = cpg.parse(*args)
         self.ast = self.g.edge_subgraph([e for e, d in self.g.edges.items()
                             if d["type"] == 'IS_AST_PARENT']).copy()
         self.cfg = self.g.edge_subgraph([e for e, d in self.g.edges.items()

--- a/refactorings/loop_exchange.py
+++ b/refactorings/loop_exchange.py
@@ -1,79 +1,64 @@
 """Loop exchange: exchange for loop with while"""
 
 from refactorings.bad_node_exception import BadNodeException
-from refactorings.base import BaseTransformation, JoernTransformation
+from refactorings.base import BaseTransformation, JoernTransformation, SrcMLTransformation
 from refactorings.joern import JoernLocation
 import re
+from srcml import E
 
 
-class LoopExchange(JoernTransformation):
-    def get_targets(self):
-        return [n for n, d in self.joern.ast.nodes.items() if d["type"] == 'ForStatement']
+class LoopExchange(SrcMLTransformation):
+    def get_targets(self, **kwargs):
+        return self.srcml.xp('//src:for')
 
     def _apply(self, target):
-        succ = list(self.joern.ast.successors(target))
-        def pop_node(nodes, node_type):
-            found = next((n for n in nodes if self.joern.node_type[n] == node_type), None)
-            if found is not None:
-                nodes.remove(found)
-            return found
-        stmt = succ.pop()
-        assert self.joern.node_type[stmt].endswith('Statement')
-        init = pop_node(succ, 'ForInit')
-        cond = pop_node(succ, 'Condition')
-        post = succ.pop() if len(succ) > 0 else None
-        if post is not None:
-            assert self.joern.node_type[post].endswith('Expression'), f'post (located at {self.joern.node_location[post]}) should be of some Expression type but is actually {self.joern.node_type[post]}'
-        if stmt is None:
-            raise BadNodeException(f'Loop at location {self.joern.node_location[target]} has no body')
-        stmt_is_compound = self.joern.node_type[stmt] == 'CompoundStatement'
+        control = self.srcml.xp(target, 'src:control')[0]
+        init = self.srcml.xp(control, 'src:init')[0]
+        condition = self.srcml.xp(control, 'src:condition')[0]
+        incr = self.srcml.xp(control, 'src:incr')[0]
+        block = self.srcml.xp(target, 'src:block')[0]
+        insert_idx = target.getparent().index(target)
 
-        # Get locations
-        loop_loc = self.joern.node_location[target]
-        stmt_loc = self.joern.node_location[stmt]
+        try:
+            control_tail = control.tail
+            control_end = control.getchildren()[-1].tail
+            parent = target.getparent()
+            parent.remove(target)
+            if len(incr) > 0:
+                block_content = block.getchildren()[0]
+                incr.tail = ';' + block_content.getchildren()[-1].tail
+                block_content.getchildren()[-1].tail = block_content.text
+                block_content.insert(len(block_content), incr)
+            if len(init) > 0:
+                init.tail = target.tail
+                parent.insert(insert_idx, init)
+                insert_idx += 1
+            if len(condition) == 0:
+                condition.text = None
+                for c in condition.getchildren():
+                    condition.remove(c)
+                literal_true = E.expr(
+                    E.literal(
+                        '1',
+                        {"type": 'number'}
+                    )
+                )
+                condition.insert(0, literal_true)
+            condition.text = control.text
+            self.srcml.xp(condition, 'src:expr')[0].tail = control_end + control_tail
 
-        # Get the correct whitespace to indent the loop and the body
-        loop_indent = self.get_indent(self.old_lines[loop_loc.line-1])
-        if stmt_is_compound:
-            stmt_first_line_begin = stmt_loc.offset + self.old_text[stmt_loc.offset:].find('\n') + 1
-            stmt_first_line_end = stmt_first_line_begin + self.old_text[stmt_first_line_begin:].find('\n')
-            body_indent = self.get_indent(self.old_text[stmt_first_line_begin:stmt_first_line_end])
-        else:
-            body_indent = self.get_indent(self.old_lines[stmt_loc.line-1])
+            new_while_stmt = E(
+                'while',
+                'while',
+                condition,
+                block,
+                target.tail
+            )
+            parent.insert(insert_idx, new_while_stmt)
+            self.srcml.apply_changes()
+        except Exception:
+            self.srcml.revert_changes()
+            raise
 
-        # Replace for loop with while (try to preserve whitespace before/after the loop, no guarantees about inside the loop)
-        new_text = self.old_text[:loop_loc.offset]
-
-        # Add init
-        if init is not None:
-            init_code = self.joern.node_code[init].strip()
-            init_code = '; '.join(c.strip() for c in re.split(r',|;', init_code) if len(c.strip()) > 0)
-            new_text += init_code + ';\n' + loop_indent
-
-        # Add loop header
-        if cond is None:
-            cond_code = 'true'  # Empty condition is equivalent to while(true) (source: https://en.cppreference.com/w/cpp/language/for)
-        else:
-            cond_code = self.joern.node_code[cond].strip()
-        new_text += f'while ({cond_code})\n'
-
-        # Get post line to add to loop body if applicable
-        if post is None:
-            post_line = ''
-        else:
-            post_code = self.joern.node_code[post].strip()
-            post_line = body_indent + post_code + ';\n'
-        stmt_code = self.old_text[stmt_loc.offset:stmt_loc.end_offset+1].strip()
-        # Add loop body
-        if stmt_is_compound:
-            last_line_offset = stmt_code.rfind('\n')+1
-            body_code = stmt_code[:last_line_offset] + post_line + stmt_code[last_line_offset:]
-        else:
-            body_code = '{' + body_indent + stmt_code + '\n' + post_line + loop_indent + '}'
-        new_text += loop_indent + body_code
-
-        # Done replacing, add text immediately following the end of the last statement
-        new_text += self.old_text[stmt_loc.end_offset+1:]
-
-        lines = new_text.splitlines(keepends=True)
-        return lines
+        new_text = self.srcml.load_c_code()
+        return new_text.splitlines(keepends=True)

--- a/refactorings/loop_exchange.py
+++ b/refactorings/loop_exchange.py
@@ -1,12 +1,12 @@
 """Loop exchange: exchange for loop with while"""
 
 from refactorings.bad_node_exception import BadNodeException
-from refactorings.base import BaseTransformation
+from refactorings.base import BaseTransformation, JoernTransformation
 from refactorings.joern import JoernLocation
 import re
 
 
-class LoopExchange(BaseTransformation):
+class LoopExchange(JoernTransformation):
     def get_targets(self):
         return [n for n, d in self.joern.ast.nodes.items() if d["type"] == 'ForStatement']
 

--- a/refactorings/loop_exchange_joern.py
+++ b/refactorings/loop_exchange_joern.py
@@ -1,0 +1,79 @@
+"""Loop exchange: exchange for loop with while"""
+
+from refactorings.bad_node_exception import BadNodeException
+from refactorings.base import BaseTransformation, JoernTransformation
+from refactorings.joern import JoernLocation
+import re
+
+
+class LoopExchangeJoernVersion(JoernTransformation):
+    def get_targets(self):
+        return [n for n, d in self.joern.ast.nodes.items() if d["type"] == 'ForStatement']
+
+    def _apply(self, target):
+        succ = list(self.joern.ast.successors(target))
+        def pop_node(nodes, node_type):
+            found = next((n for n in nodes if self.joern.node_type[n] == node_type), None)
+            if found is not None:
+                nodes.remove(found)
+            return found
+        stmt = succ.pop()
+        assert self.joern.node_type[stmt].endswith('Statement')
+        init = pop_node(succ, 'ForInit')
+        cond = pop_node(succ, 'Condition')
+        post = succ.pop() if len(succ) > 0 else None
+        if post is not None:
+            assert self.joern.node_type[post].endswith('Expression'), f'post (located at {self.joern.node_location[post]}) should be of some Expression type but is actually {self.joern.node_type[post]}'
+        if stmt is None:
+            raise BadNodeException(f'Loop at location {self.joern.node_location[target]} has no body')
+        stmt_is_compound = self.joern.node_type[stmt] == 'CompoundStatement'
+
+        # Get locations
+        loop_loc = self.joern.node_location[target]
+        stmt_loc = self.joern.node_location[stmt]
+
+        # Get the correct whitespace to indent the loop and the body
+        loop_indent = self.get_indent(self.old_lines[loop_loc.line-1])
+        if stmt_is_compound:
+            stmt_first_line_begin = stmt_loc.offset + self.old_text[stmt_loc.offset:].find('\n') + 1
+            stmt_first_line_end = stmt_first_line_begin + self.old_text[stmt_first_line_begin:].find('\n')
+            body_indent = self.get_indent(self.old_text[stmt_first_line_begin:stmt_first_line_end])
+        else:
+            body_indent = self.get_indent(self.old_lines[stmt_loc.line-1])
+
+        # Replace for loop with while (try to preserve whitespace before/after the loop, no guarantees about inside the loop)
+        new_text = self.old_text[:loop_loc.offset]
+
+        # Add init
+        if init is not None:
+            init_code = self.joern.node_code[init].strip()
+            init_code = '; '.join(c.strip() for c in re.split(r',|;', init_code) if len(c.strip()) > 0)
+            new_text += init_code + ';\n' + loop_indent
+
+        # Add loop header
+        if cond is None:
+            cond_code = 'true'  # Empty condition is equivalent to while(true) (source: https://en.cppreference.com/w/cpp/language/for)
+        else:
+            cond_code = self.joern.node_code[cond].strip()
+        new_text += f'while ({cond_code})\n'
+
+        # Get post line to add to loop body if applicable
+        if post is None:
+            post_line = ''
+        else:
+            post_code = self.joern.node_code[post].strip()
+            post_line = body_indent + post_code + ';\n'
+        stmt_code = self.old_text[stmt_loc.offset:stmt_loc.end_offset+1].strip()
+        # Add loop body
+        if stmt_is_compound:
+            last_line_offset = stmt_code.rfind('\n')+1
+            body_code = stmt_code[:last_line_offset] + post_line + stmt_code[last_line_offset:]
+        else:
+            body_code = '{' + body_indent + stmt_code + '\n' + post_line + loop_indent + '}'
+        new_text += loop_indent + body_code
+
+        # Done replacing, add text immediately following the end of the last statement
+        new_text += self.old_text[stmt_loc.end_offset+1:]
+
+        lines = new_text.splitlines(keepends=True)
+        return lines

--- a/refactorings/permute_stmt.py
+++ b/refactorings/permute_stmt.py
@@ -101,8 +101,7 @@ class PermuteStmt(BaseTransformation):
         """Swap 2 lines in a file's text and return the lines in the text"""
         def to_line(loc):
             return loc.line
-        with open(self.c_file) as f:
-            lines = f.readlines()
+        lines = list(self.old_lines)
         a_idx = to_line(self.joern.node_location[a])-1
         b_idx = to_line(self.joern.node_location[b])-1
         lines[a_idx], lines[b_idx] = lines[b_idx], lines[a_idx]

--- a/refactorings/permute_stmt.py
+++ b/refactorings/permute_stmt.py
@@ -5,10 +5,10 @@ from pathlib import Path
 import networkx as nx
 
 import cpg
-from refactorings.base import BaseTransformation
+from refactorings.base import BaseTransformation, JoernTransformation
 
 
-class PermuteStmt(BaseTransformation):
+class PermuteStmt(JoernTransformation):
 
     def get_basic_blocks(self):
         """Return a list of all basic blocks, where a block is a list of statements"""

--- a/refactorings/project.py
+++ b/refactorings/project.py
@@ -5,107 +5,75 @@ import traceback
 import datetime
 import tempfile
 import os
+import logging
+logger = logging.getLogger(__name__)
 
 
 class TransformationProject:
-    def __init__(self, transforms, picker, project, c_filename, exclude, keep_tmp, avoid):
+    def __init__(self, transforms, picker, c_filename, c_code, avoid=None):
         self.transforms = copy.deepcopy(transforms)
         self.picker = picker
-        self.exclude = exclude
 
-        self.project, self.c_filename = project, c_filename
-        self.original_project, self.original_c_filename = self.project, self.c_filename
+        self.original_c_filename = self.c_filename = c_filename
+        self.c_code = c_code
 
-        self.keep_tmp = keep_tmp
         self.avoid = avoid
-                
+
     def __enter__(self):
         self.tmp_dir = Path(tempfile.mkdtemp())
 
-        tmp_project = self.tmp_dir / self.project.name
-        shutil.copytree(self.project, tmp_project, ignore=self.exclude)
-
-        tmp_c_filename = tmp_project / os.path.relpath(self.c_filename, self.project)
-        shutil.copy(self.c_filename, tmp_c_filename)
-
-        self.project = tmp_project
+        tmp_c_filename = self.tmp_dir / self.c_filename
+        if self.c_code is None:
+            shutil.copy(self.c_filename, tmp_c_filename)
+        else:
+            with open(tmp_c_filename, 'w') as f:
+                f.write(self.c_code)
         self.c_filename = tmp_c_filename
-        
-        #self.transform_filename = self.c_filename.parent / (self.c_filename.stem + '.transforms.txt')
-        #if self.transform_filename.exists():
-        #    self.transform_filename.unlink()
-        
-        self.transformations_applied = []
-        
+
         return self
 
     def __exit__(self, type, value, traceback):
-        if not self.keep_tmp:
-            shutil.rmtree(self.tmp_dir)
-
-    #def log_transforms_applied(self, t):
-    #    """Log after each transform, for debugging in case the procedure is errored."""
-    #    with open(self.transform_filename, 'a') as f:
-    #        f.write(f'{t.__name__}\n')
+        shutil.rmtree(self.tmp_dir)
 
     def log(self, *args):
-        with open('app.log', 'a') as f:
-            print(self.original_c_filename.name + ':', *args, file=f)
+        logger.info('[%s] %s', self.original_c_filename, ' '.join(str(a) for a in args))
 
     def log_error(self, *args):
-        with open('errors.log', 'a') as f:
-            print(self.original_c_filename.name + ':', *args, file=f)
-
-    def apply(self, t):
-        try:
-            #new_lines = t(self.c_filename, picker=self.picker, project=self.project, exclude=self.exclude, tmp_dir=self.tmp_dir, avoid_lines=self.avoid).run()
-            new_lines = t(self.c_filename, picker=self.picker, project=self.project, exclude=self.exclude, tmp_dir=self.project.parent, avoid_lines=self.avoid).run()
-
-            # If it could not be applied, skip this transformation.
-            # Most commonly means the transformation had no slot.
-            if new_lines == None:
-                self.log(f'Could not apply {t.__name__}.')
-                self.transforms.remove(t)
-                return
-
-            # Successfully applied the transformation.
-            #self.log_transforms_applied(t)
-            with open(self.c_filename, 'w') as f:
-                f.writelines(new_lines)
-            #shutil.copy2(self.c_filename, self.c_filename.with_suffix(f'.c.{len(self.transformations_applied)}.{t.__name__}'))
-            self.transforms.remove(t)
-            self.transformations_applied.append(t)
-            self.log('Applied', t.__name__)
-        except Exception as e:
-            self.log(f'Error applying {t.__name__}: {e}. Stack trace written to errors.log.')
-            self.log_error(f'***Exception {self.project} {self.original_project} {self.original_c_filename} {t.__name__} ({datetime.datetime.now()})***', e, '\n', traceback.format_exc())
-            self.transforms.remove(t)
+        logger.error('[%s] %s', self.original_c_filename, ' '.join(str(a) for a in args))
 
     def apply_all(self, return_applied=False):
         """Do C source-to-source translation"""
 
-        self.transformations_applied = []
+        transformations_applied = []
 
         # Apply all transforms one at a time
-        #shutil.copy2(self.c_filename, self.tmp_dir / (self.c_filename.name + '.back'))
+        new_lines = None
         while len(self.transforms) > 0:
             if len(self.transforms) == 0:
                 self.log('Quitting early, ran out of transforms')
                 break
             t = self.transforms[0]
-            self.apply(t)
+            try:
+                new_lines = t(self.c_filename, picker=self.picker, avoid_lines=self.avoid).run()
+
+                # If it could not be applied, skip this transformation.
+                # Most commonly means the transformation had no slot.
+                if new_lines == None:
+                    self.log(f'Could not apply {t.__name__}.')
+                    self.transforms.remove(t)
+                    continue
+
+                # Successfully applied the transformation.
+                with open(self.c_filename, 'w') as f:
+                    f.writelines(new_lines)
+                self.transforms.remove(t)
+                transformations_applied.append(t)
+                self.log('Applied', t.__name__)
+            except Exception as e:
+                self.log(f'Error applying {t.__name__}: {e}. Stack trace written to errors.log.')
+                self.log_error(self.c_filename, t.__name__, e, '\n', traceback.format_exc())
+                self.transforms.remove(t)
         if return_applied:
-            return Path(self.c_filename), self.transformations_applied
+            return new_lines, transformations_applied
         else:
-            return Path(self.c_filename)
-
-
-class TransformationsFactory:
-    def __init__(self, transforms, picker):
-        self.transforms = copy.deepcopy(list(transforms))
-        self.picker = picker
-
-    def make_project(self, c_filename, project=None, exclude=None, keep_tmp=False, avoid=None):
-        if project is None:
-            project = c_filename.parent
-        return TransformationProject(self.transforms, self.picker, project, c_filename, exclude, keep_tmp=keep_tmp, avoid=avoid)
+            return new_lines

--- a/refactorings/random_word.py
+++ b/refactorings/random_word.py
@@ -1,9 +1,11 @@
 import random
 import string
 import re
+from pathlib import Path
 
+words_file = Path(__file__).parent.parent / 'words'
 rng = random.Random(0)
-with open('words') as f:
+with open(words_file) as f:
     all_words = [re.sub('[^0-9a-zA-Z_]', '', w.strip()) for w in f.read().splitlines()]
 
 def get_random_word():

--- a/refactorings/rename_variable.py
+++ b/refactorings/rename_variable.py
@@ -27,5 +27,3 @@ class RenameVariable(SrcMLTransformation):
             raise
         new_code = self.srcml.load_c_code()
         return new_code.splitlines(keepends=True)
-
-

--- a/refactorings/rename_variable_joern.py
+++ b/refactorings/rename_variable_joern.py
@@ -1,0 +1,43 @@
+
+"""Rename Variable: replace a local variable's name."""
+
+from refactorings.base import JoernTransformation
+from refactorings.random_word import get_random_word
+import networkx.algorithms.dag as nx_algo
+
+class RenameVariableJoernVersion(JoernTransformation):
+    def get_targets(self):
+        id_decls = [n for n in self.joern.g.nodes() if self.joern.node_type[n] == 'IdentifierDecl']
+        all_targets = []
+        for d in id_decls:
+            children = list(self.joern.ast.successors(d))
+            if self.joern.node_type[children[0]] == 'IdentifierDeclType' and self.joern.node_type[children[1]] == 'Identifier':
+                all_targets.append(children[1])
+        return all_targets
+
+    def _apply(self, target):
+        old_target_name = self.joern.node_code[target]
+        new_target_name = get_random_word()
+
+        function_def = target
+        while self.joern.node_type[function_def] != 'FunctionDef':
+            function_def = next(self.joern.ast.predecessors(function_def))
+        nodes_in_function = nx_algo.descendants(self.joern.ast, function_def)
+        var_refs = [n for n in nodes_in_function
+                    if self.joern.node_type[n] == 'Identifier'
+                    and self.joern.node_code[n] == old_target_name]
+        var_refs = sorted(var_refs, key=lambda n: self.joern.node_location[n].offset)
+
+        assert len(var_refs) > 0, f'no references to variable {old_target_name}'
+
+        new_text = ''
+        last_offset = 0
+        for v in var_refs:
+            loc = self.joern.node_location[v]
+            new_text += self.old_text[last_offset:loc.offset]
+            new_text += new_target_name
+            last_offset = loc.end_offset+1
+        new_text += self.old_text[last_offset:]
+
+        return new_text.splitlines(keepends=True)
+

--- a/refactorings/switch_exchange.py
+++ b/refactorings/switch_exchange.py
@@ -41,7 +41,7 @@ class SwitchExchange(SrcMLTransformation):
                     block = [c]
             else:
                 block.append(c)
-                if self.srcml.tag(c) in ('break', 'return'):
+                if self.srcml.tag(c) in ('break', 'return', 'continue', 'empty_stmt'):
                     block_ender_ok = True
                 elif self.srcml.tag(c) not in ('comment',):
                     block_ender_ok = False

--- a/refactorings/switch_exchange.py
+++ b/refactorings/switch_exchange.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 import copy
 from refactorings.bad_node_exception import BadNodeException
 
-from refactorings import clang_format
+# from refactorings import clang_format
 from refactorings.base import BaseTransformation
 from refactorings.joern import JoernLocation
 import logging

--- a/refactorings/switch_exchange.py
+++ b/refactorings/switch_exchange.py
@@ -5,114 +5,131 @@ import copy
 from refactorings.bad_node_exception import BadNodeException
 
 # from refactorings import clang_format
-from refactorings.base import BaseTransformation, JoernTransformation
+from refactorings.base import BaseTransformation, JoernTransformation, SrcMLTransformation
 from refactorings.joern import JoernLocation
 import logging
 import re
+from srcml import E
 
 
-class SwitchExchange(JoernTransformation):
+class SwitchExchange(SrcMLTransformation):
     logger = logging.getLogger('SwitchExchange')
 
-    def get_targets(self):
-        return [n for n, d in self.joern.ast.nodes.items() if d["type"] == 'SwitchStatement']
+    def get_targets(self, **kwargs):
+        return self.srcml.xp('//src:switch')
 
     def _apply(self, target):
+        cond = self.srcml.xp(target, 'src:condition')[0]
+        # case = self.srcml.xp(target, 'src:case')[0]
+        block_content = self.srcml.xp(target, 'src:block')[0][0]
 
-        # TODO: filter switches by ones with static expression (no function call).
-        cond, compound = self.joern.ast.successors(target)
-        children = sorted(self.joern.ast.successors(compound))
-
-        assert len(children) > 0, f'empty switch statement'
-        stmts_in_compound = list(children)
+        children = list(block_content)
+        assert len(children) > 0, 'empty switch statement'
 
         block = []
-        block_ender = None  # Last statement in the block. TODO: block_ender should be the true last statement to execute in the block, not just the last statement
+        block_ender = None  # Last statement in the block
         blocks = []
         while len(children) > 0:
             c = children.pop(0)
-            if self.joern.node_type[c] == 'Label':
-                if len(block) == 0 or all(self.joern.node_type[n] == 'Label' for n in block):
+            if self.srcml.tag(c) in ('case', 'default'):
+                if len(block) == 0 or all(self.srcml.tag(n) == 'case' for n in block):
                     block.append(c)
                 else:
                     if block_ender is not None:
                         # Check that there are no fallthroughs and that last statement is break
-                        assert self.joern.node_type[block_ender] in ('BreakStatement', 'ReturnStatement'),\
-                            f'expected BreakStatement but got {self.joern.node_type[block_ender]}'
+                        assert self.srcml.tag(block_ender) in ('break', 'return'),\
+                            f'expected tag to end block but got {block_ender.tag}'
                     blocks.append(block)
                     block_ender = None
-                    block = []
-                    block.append(c)
+                    block = [c]
             else:
                 block.append(c)
                 block_ender = c
         blocks.append(block)
         self.logger.debug(f'{len(blocks)=}')
 
-        # TODO: check no fall-through using CFG
+        try:
+            block_content_text = block_content.text
+            ifs = []
+            cond_expr = self.srcml.xp(cond, 'src:expr')[0]
+            cond_expr.tail = ' '
+            for i, block in enumerate(blocks):
+                is_default = False
+                labels, stmts = [], []
+                for n in block:
+                    if self.srcml.tag(n) == 'default':
+                        assert i == len(blocks)-1, 'fallthrough not supported'
+                        is_default = True
+                        labels.append(n)
+                    elif self.srcml.tag(n) == 'case':
+                        labels.append(n)
+                    elif self.srcml.tag(n) != 'break':
+                        stmts.append(n)
+                self.logger.debug(f'{labels=} {stmts=}')
 
-        target_location = self.joern.node_location[target]
-        switch_indent = self.get_indent(self.old_lines[target_location.line])
-        # Find the first child that isn't a label and get its indentation.
-        # If there is none, default to the first label.
-        for n in stmts_in_compound:
-            first_body_child = n
-            if self.joern.node_type[n] != 'Label':
-                break
-        first_body_child = self.joern.node_location[first_body_child]
-        body_indent = self.get_indent(self.old_lines[first_body_child.line])
+                stmts[-1].tail = block_content_text
 
-        compound_location = self.joern.node_location[compound]
+                if is_default:
+                    if_type = 'else'
+                    if_text = 'else'
+                else:
+                    if_type = 'if'
+                    if_text = 'if'
+                if not is_default and i > 0:
+                    if_attrs = {"type": 'elseif'}
+                    if_text = 'else if'
+                else:
+                    if_attrs = {}
+                self.logger.debug(f'{if_type=} {if_text=} {if_attrs=}')
 
-        new_text = self.old_text[:target_location.offset]
-        # Add in new if/elses
-        all_codes = []
-        for i, block in enumerate(blocks):
-            labels, stmts = [], []
-            for n in block:
-                if self.joern.node_type[n] == 'Label':
-                    labels.append(n)
-                elif self.joern.node_type[n] != 'BreakStatement':
-                    stmts.append(n)
-            self.logger.debug(f'{labels=} {stmts=}')
+                args = [
+                    if_type,
+                    f'{if_text} ',
+                    if_attrs
+                ]
 
-            # If condition
-            def get_if_condition():
-                switch_cond_code = self.joern.node_code[cond]
-                label_exprs = []
-                for n in labels:
-                    label_code = self.joern.node_code[n]
-                    m = re.fullmatch(r'\s*default\s*:', label_code)
-                    if m is not None:
-                        if i != len(blocks)-1:
-                            raise NotImplementedError(f'default in the middle of a switch')
-                        return 'else'
-                    else:
-                        m = re.fullmatch(r'\s*case\s*(.*)\s*:', label_code)
-                        if m is None:
-                            m = re.fullmatch(r'\s*case\s*(.*)\s*:', label_code)
-                            raise BadNodeException(f'Could not parse {label_code} for label')
+                if not is_default:
+                    exprs = []
+                    for j, n in enumerate(labels):
+                        e = n[0]
+                        if j < len(labels)-1:
+                            e.tail = ' '
                         else:
-                            label_code = m.group(1)
-                            label_exprs.append(label_code.strip())
-                cond_expr_code = ' || '.join((f'{switch_cond_code} == {code}') for code in label_exprs)
-                if_cond_code = f'if ({cond_expr_code})'
-                if i > 0:
-                    if_cond_code = 'else ' + if_cond_code
-                return if_cond_code
-            if_cond_code = get_if_condition()
-            self.logger.debug(f'if_cond_code="{if_cond_code}"')
+                            e.tail = None
+                        exprs.append(e)
+                    if_cond_expr_contents = []
+                    for j, expr in enumerate(exprs):
+                        if_cond_expr_contents.append(copy.deepcopy(cond_expr))
+                        if_cond_expr_contents.append(E.operator('==', ' '))
+                        if_cond_expr_contents.append(expr)
+                        if j < len(exprs)-1:
+                            if_cond_expr_contents.append(E.operator('||', ' '))
+                    args.append(E.condition(
+                        '(',
+                        E.expr(
+                            *if_cond_expr_contents,
+                            ')'
+                        )
+                    ))
 
-            # Wrap code statements in {}
-            stmts_code = ('\n' + body_indent).join(self.joern.node_code[stmt] for stmt in stmts)
-            stmts_code = switch_indent + '{\n' + body_indent + stmts_code + '\n' + switch_indent + '}'
-            self.logger.debug(f'stmts_code="{stmts_code}"')
+                if i == len(blocks)-1:
+                    ender = '}'
+                else:
+                    ender = '}' + block_content_text
+                args.append(E.block(E.block_content(block_content_text + '{' + labels[-1].tail, *stmts, ender)))
 
-            all_code = if_cond_code + '\n' + stmts_code
-            self.logger.debug(f'all_code="{all_code}"')
-            all_codes.append(all_code)
-        new_text += ('\n' + switch_indent).join(all_codes)
-        new_text += self.old_text[compound_location.end_offset+1:]
+                if_part = E(*args)
+                ifs.append(if_part)
+            if_stmt = E.if_stmt(*ifs)
+            if_stmt.tail = target.tail
+            parent = target.getparent()
+            insert_idx = parent.index(target)
+            parent.remove(target)
+            parent.insert(insert_idx, if_stmt)
+            self.srcml.apply_changes()
+        except Exception:
+            self.srcml.revert_changes()
+            raise
 
-        new_lines = new_text.splitlines(keepends=True)
-        return new_lines
+        new_text = self.srcml.load_c_code()
+        return new_text.splitlines(keepends=True)

--- a/refactorings/switch_exchange.py
+++ b/refactorings/switch_exchange.py
@@ -5,13 +5,13 @@ import copy
 from refactorings.bad_node_exception import BadNodeException
 
 # from refactorings import clang_format
-from refactorings.base import BaseTransformation
+from refactorings.base import BaseTransformation, JoernTransformation
 from refactorings.joern import JoernLocation
 import logging
 import re
 
 
-class SwitchExchange(BaseTransformation):
+class SwitchExchange(JoernTransformation):
     logger = logging.getLogger('SwitchExchange')
 
     def get_targets(self):

--- a/refactorings/switch_exchange_joern.py
+++ b/refactorings/switch_exchange_joern.py
@@ -1,0 +1,118 @@
+
+# Refactoring: exchange switch with if/else
+from collections import OrderedDict
+import copy
+from refactorings.bad_node_exception import BadNodeException
+
+# from refactorings import clang_format
+from refactorings.base import BaseTransformation, JoernTransformation
+from refactorings.joern import JoernLocation
+import logging
+import re
+
+
+class SwitchExchangeJoernVersion(JoernTransformation):
+    logger = logging.getLogger('SwitchExchange')
+
+    def get_targets(self):
+        return [n for n, d in self.joern.ast.nodes.items() if d["type"] == 'SwitchStatement']
+
+    def _apply(self, target):
+
+        # TODO: filter switches by ones with static expression (no function call).
+        cond, compound = self.joern.ast.successors(target)
+        children = sorted(self.joern.ast.successors(compound))
+
+        assert len(children) > 0, f'empty switch statement'
+        stmts_in_compound = list(children)
+
+        block = []
+        block_ender = None  # Last statement in the block. TODO: block_ender should be the true last statement to execute in the block, not just the last statement
+        blocks = []
+        while len(children) > 0:
+            c = children.pop(0)
+            if self.joern.node_type[c] == 'Label':
+                if len(block) == 0 or all(self.joern.node_type[n] == 'Label' for n in block):
+                    block.append(c)
+                else:
+                    if block_ender is not None:
+                        # Check that there are no fallthroughs and that last statement is break
+                        assert self.joern.node_type[block_ender] in ('BreakStatement', 'ReturnStatement'),\
+                            f'expected BreakStatement but got {self.joern.node_type[block_ender]}'
+                    blocks.append(block)
+                    block_ender = None
+                    block = []
+                    block.append(c)
+            else:
+                block.append(c)
+                block_ender = c
+        blocks.append(block)
+        self.logger.debug(f'{len(blocks)=}')
+
+        # TODO: check no fall-through using CFG
+
+        target_location = self.joern.node_location[target]
+        switch_indent = self.get_indent(self.old_lines[target_location.line])
+        # Find the first child that isn't a label and get its indentation.
+        # If there is none, default to the first label.
+        for n in stmts_in_compound:
+            first_body_child = n
+            if self.joern.node_type[n] != 'Label':
+                break
+        first_body_child = self.joern.node_location[first_body_child]
+        body_indent = self.get_indent(self.old_lines[first_body_child.line])
+
+        compound_location = self.joern.node_location[compound]
+
+        new_text = self.old_text[:target_location.offset]
+        # Add in new if/elses
+        all_codes = []
+        for i, block in enumerate(blocks):
+            labels, stmts = [], []
+            for n in block:
+                if self.joern.node_type[n] == 'Label':
+                    labels.append(n)
+                elif self.joern.node_type[n] != 'BreakStatement':
+                    stmts.append(n)
+            self.logger.debug(f'{labels=} {stmts=}')
+
+            # If condition
+            def get_if_condition():
+                switch_cond_code = self.joern.node_code[cond]
+                label_exprs = []
+                for n in labels:
+                    label_code = self.joern.node_code[n]
+                    m = re.fullmatch(r'\s*default\s*:', label_code)
+                    if m is not None:
+                        if i != len(blocks)-1:
+                            raise NotImplementedError(f'default in the middle of a switch')
+                        return 'else'
+                    else:
+                        m = re.fullmatch(r'\s*case\s*(.*)\s*:', label_code)
+                        if m is None:
+                            m = re.fullmatch(r'\s*case\s*(.*)\s*:', label_code)
+                            raise BadNodeException(f'Could not parse {label_code} for label')
+                        else:
+                            label_code = m.group(1)
+                            label_exprs.append(label_code.strip())
+                cond_expr_code = ' || '.join((f'{switch_cond_code} == {code}') for code in label_exprs)
+                if_cond_code = f'if ({cond_expr_code})'
+                if i > 0:
+                    if_cond_code = 'else ' + if_cond_code
+                return if_cond_code
+            if_cond_code = get_if_condition()
+            self.logger.debug(f'if_cond_code="{if_cond_code}"')
+
+            # Wrap code statements in {}
+            stmts_code = ('\n' + body_indent).join(self.joern.node_code[stmt] for stmt in stmts)
+            stmts_code = switch_indent + '{\n' + body_indent + stmts_code + '\n' + switch_indent + '}'
+            self.logger.debug(f'stmts_code="{stmts_code}"')
+
+            all_code = if_cond_code + '\n' + stmts_code
+            self.logger.debug(f'all_code="{all_code}"')
+            all_codes.append(all_code)
+        new_text += ('\n' + switch_indent).join(all_codes)
+        new_text += self.old_text[compound_location.end_offset+1:]
+
+        new_lines = new_text.splitlines(keepends=True)
+        return new_lines

--- a/srcml.py
+++ b/srcml.py
@@ -25,7 +25,7 @@ else:
 
 
 namespaces = {'src': 'http://www.srcML.org/srcML/src'}
-E = ElementMaker(namespace="http://www.srcML.org/srcML/src")
+E = ElementMaker(nsmap=namespaces)
 
 
 # Print XML from root

--- a/srcml.py
+++ b/srcml.py
@@ -97,3 +97,7 @@ class SrcMLInfo:
             node = args[0]
             query = args[1]
         return node.xpath(query, namespaces=namespaces)
+
+    @classmethod
+    def tag(cls, node):
+        return etree.QName(node).localname

--- a/srcml.py
+++ b/srcml.py
@@ -1,0 +1,99 @@
+"""
+Modifying AST with `srcml`. Parses very OK! Can we modify??
+"""
+
+from lxml import etree
+from lxml.builder import ElementMaker
+import subprocess
+from pathlib import Path
+import re
+import os
+import copy
+
+import logging
+logger = logging.getLogger(__name__)
+
+srcml_install = Path(__file__).parent / 'srcml'
+srcml_exe = srcml_install / 'bin/srcml'
+assert srcml_exe.exists()
+
+srcml_env = copy.deepcopy(os.environ)
+if "LD_LIBRARY_PATH" in srcml_env:
+    srcml_env["LD_LIBRARY_PATH"] = str(srcml_install / 'lib') + ':' + srcml_env["LD_LIBRARY_PATH"]
+else:
+    srcml_env["LD_LIBRARY_PATH"] = str(srcml_install / 'lib')
+
+
+namespaces = {'src': 'http://www.srcML.org/srcML/src'}
+E = ElementMaker(namespace="http://www.srcML.org/srcML/src")
+
+
+# Print XML from root
+def prettyprint(node, return_string=False):
+    s = etree.tostring(node, encoding="unicode", pretty_print=True)
+    if return_string:
+        return s
+    else:
+        print(s)
+
+
+# prettyprint(xmldata)
+
+
+def tagname(node):
+    return etree.QName(node).localname
+
+
+def start_pos(node):
+    # prettyprint(node)
+    return node.get('{http://www.srcML.org/srcML/position}start')
+
+
+def get_space(node, front_back):
+    if front_back == 'front':
+        regex = rf'^<{etree.QName(node).localname}[^>]+>(\s+)'
+    elif front_back == 'back':
+        regex = r'(\s+)$'
+    else:
+        raise
+    m = re.search(regex, etree.tostring(node, encoding='unicode'))
+    if m:
+        return m.group(1)
+    else:
+        return ''
+
+
+class SrcMLInfo:
+    def __init__(self, c_code=None):
+        self.c_code = c_code
+        self.xml = None
+        self.xml_root = None
+        self.load_xml()
+
+    def load_xml(self):
+        proc = subprocess.Popen([str(srcml_exe), '-lC'],
+                                stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+        self.xml = proc.communicate(input=self.c_code.encode('utf-8'))[0]
+        self.xml_root = etree.fromstring(self.xml)
+        return self.xml
+
+    def load_c_code(self):
+        proc = subprocess.Popen([str(srcml_exe)], stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+        self.c_code = proc.communicate(input=self.xml)[0].decode('utf-8')
+        logger.debug('new C code:\n%s', self.c_code)
+        return self.c_code
+
+    def revert_changes(self):
+        self.xml_root = etree.fromstring(self.xml_root)
+
+    def apply_changes(self):
+        self.xml = etree.tostring(self.xml_root)
+
+    def xp(self, *args):
+        if len(args) == 1:
+            node = self.xml_root
+            query = args[0]
+        else:
+            node = args[0]
+            query = args[1]
+        return node.xpath(query, namespaces=namespaces)

--- a/srcml.py
+++ b/srcml.py
@@ -25,7 +25,7 @@ else:
 
 
 namespaces = {'src': 'http://www.srcML.org/srcML/src'}
-E = ElementMaker(nsmap=namespaces)
+E = ElementMaker(namespace=namespaces["src"], nsmap=namespaces)
 
 
 # Print XML from root
@@ -84,7 +84,7 @@ class SrcMLInfo:
         return self.c_code
 
     def revert_changes(self):
-        self.xml_root = etree.fromstring(self.xml_root)
+        self.xml_root = etree.fromstring(self.xml)
 
     def apply_changes(self):
         self.xml = etree.tostring(self.xml_root)

--- a/tests/data/acceptance/loop_exchange/chrome_debian/18159_0.patch
+++ b/tests/data/acceptance/loop_exchange/chrome_debian/18159_0.patch
@@ -7,7 +7,7 @@
 - for ( ;
 - ;
 - ) {
-+ while (true)
++ while( 1)
 + {
   int32_t c1 = ( uint8_t ) * s1 ++ ;
   int32_t c2 = ( uint8_t ) * s2 ++ ;

--- a/tests/data/acceptance/loop_exchange/chrome_debian/4201_0.patch
+++ b/tests/data/acceptance/loop_exchange/chrome_debian/4201_0.patch
@@ -7,8 +7,8 @@
 - for ( p = * env_free ;
 - * p != 0 ;
 - ) {
-+ p = * env_free;
-+ while (* p != 0)
++ p = * env_free ;
++ while( * p != 0)
 + {
   if ( * p ++ == ' ' ) {
   n ++ ;

--- a/tests/data/acceptance/loop_exchange/chrome_debian/5919_0.patch
+++ b/tests/data/acceptance/loop_exchange/chrome_debian/5919_0.patch
@@ -7,8 +7,8 @@
 - for ( p = g_list_first ( actions ) ;
 - p ;
 - p = p -> next ) {
-+ p = g_list_first ( actions );
-+ while (p)
++ p = g_list_first ( actions ) ;
++ while( p )
 + {
   if ( ( ( PurplePluginAction * ) p -> data ) && purple_menu_cmp ( ( ( PurplePluginAction * ) p -> data ) -> label , "Upload buddylist to Server" ) == 0 ) {
   PurplePluginAction action ;

--- a/tests/data/timing/noop.c
+++ b/tests/data/timing/noop.c
@@ -1,0 +1,16 @@
+int main()
+{
+    int x = 0;
+    int y;
+    y = 5;
+    for (; x < 10; x += 2) {
+        y ++;
+    }
+    if (y < 10) {
+        return x;
+    }
+    else {
+        y += 5
+    }
+    return y;
+}

--- a/tests/data/timing/variables.c
+++ b/tests/data/timing/variables.c
@@ -1,0 +1,29 @@
+int main()
+{
+    int a;
+    int b;
+    int c;
+    int d;
+    int e;
+    int f;
+    int g;
+    int h;
+    int i;
+    int j;
+    int k;
+    int l;
+    int m;
+    int n;
+    int o;
+    int p;
+    int q;
+    int r;
+    int s;
+    int t;
+    int u;
+    int v;
+    int w;
+    int x;
+    int y;
+    int z;
+}

--- a/tests/data/unit/switch_exchange_comment.c
+++ b/tests/data/unit/switch_exchange_comment.c
@@ -1,0 +1,20 @@
+int main(int argc, char **argv)
+{
+    int x = 0;
+    switch (argc)
+    {
+    case 1:
+    case 2:
+        x = 5;
+        break;
+        /*Wow, this comment is confusing!*/
+    case 3:
+        // include me ;-;
+        x = 10;
+        x ++;
+        break;
+    default:
+        return argc;
+    }
+    return x;
+}

--- a/tests/data/unit/switch_exchange_empty_block.c
+++ b/tests/data/unit/switch_exchange_empty_block.c
@@ -1,0 +1,17 @@
+int main(int argc, char **argv)
+{
+    int x = 0;
+    switch (argc)
+    {
+    case 1:
+    case 2:
+        break;
+    case 3:
+        x = 10;
+        x ++;
+        break;
+    default:
+        return argc;
+    }
+    return x;
+}

--- a/tests/data/unit/switch_exchange_empty_stmt.c
+++ b/tests/data/unit/switch_exchange_empty_stmt.c
@@ -1,0 +1,18 @@
+int main(int argc, char **argv)
+{
+    int x = 0;
+    switch (argc)
+    {
+    case 1:
+    case 2:
+        break;
+        ;
+    case 3:
+        x = 10;
+        x ++;
+        break;
+    default:
+        return argc;
+    }
+    return x;
+}

--- a/tests/test_refactorings.py
+++ b/tests/test_refactorings.py
@@ -26,6 +26,7 @@ def test_loop_exchange_unit(input_file, expected):
     (test_data_root/'unit/switch_exchange.c', (7, 7)),
     (test_data_root/'unit/switch_exchange_empty_block.c', (7, 7)),
     (test_data_root/'unit/switch_exchange_comment.c', (7, 7)),
+    (test_data_root/'unit/switch_exchange_empty_stmt.c', (7, 7)),
     (test_data_root/'unit/switch_exchange_default_not_last.c', 'fallthrough'),
     (test_data_root/'unit/switch_exchange_fallthrough.c', 'expected tag to end block'),
     (test_data_root/'unit/switch_exchange_empty.c', 'empty switch statement'),

--- a/tests/test_refactorings.py
+++ b/tests/test_refactorings.py
@@ -23,9 +23,9 @@ def test_loop_exchange_unit(input_file, expected):
     assert count_diff(old_lines, new_lines) == expected
 
 @pytest.mark.parametrize("input_file,expected", [
-    (test_data_root/'unit/switch_exchange.c', (8, 8)),
-    (test_data_root/'unit/switch_exchange_default_not_last.c', 'default in the middle of a switch'),
-    (test_data_root/'unit/switch_exchange_fallthrough.c', 'expected BreakStatement but got ExpressionStatement'),
+    (test_data_root/'unit/switch_exchange.c', (7, 7)),
+    (test_data_root/'unit/switch_exchange_default_not_last.c', 'fallthrough'),
+    (test_data_root/'unit/switch_exchange_fallthrough.c', 'expected tag to end block'),
     (test_data_root/'unit/switch_exchange_empty.c', 'empty switch statement'),
 ])
 def test_switch_exchange(input_file, expected):

--- a/tests/test_refactorings.py
+++ b/tests/test_refactorings.py
@@ -25,6 +25,7 @@ def test_loop_exchange_unit(input_file, expected):
 @pytest.mark.parametrize("input_file,expected", [
     (test_data_root/'unit/switch_exchange.c', (7, 7)),
     (test_data_root/'unit/switch_exchange_empty_block.c', (7, 7)),
+    (test_data_root/'unit/switch_exchange_comment.c', (7, 7)),
     (test_data_root/'unit/switch_exchange_default_not_last.c', 'fallthrough'),
     (test_data_root/'unit/switch_exchange_fallthrough.c', 'expected tag to end block'),
     (test_data_root/'unit/switch_exchange_empty.c', 'empty switch statement'),
@@ -42,7 +43,8 @@ def test_switch_exchange(input_file, expected):
             r.run_target(target)
     else:
         new_lines = r.run_target(target)
-        assert count_diff(old_lines, new_lines) == expected, print_diff(old_lines, new_lines)
+        print_diff(old_lines, new_lines)
+        assert count_diff(old_lines, new_lines) == expected
 
 """
 Old tests

--- a/tests/test_refactorings.py
+++ b/tests/test_refactorings.py
@@ -62,6 +62,36 @@ def test_rename_variable():
     assert count_diff(old_lines, new_lines) == (5, 5)
 
 
+def test_joern_vs_srcml():
+    c_file = Path(test_data_root / 'timing/variables.c')
+    with open(c_file) as f:
+        old_lines = f.readlines()
+    import time
+    from refactorings.rename_variable_joern import RenameVariableJoernVersion
+
+    n_trials = 25
+
+    srcml_times = []
+    for i in range(n_trials):
+        begin = time.time()
+        new_lines = RenameVariable(c_file).run()
+        end = time.time()
+        srcml_times.append(end - begin)
+        assert count_diff(old_lines, new_lines) == (1, 1)
+        old_lines = new_lines
+
+    joern_times = []
+    for i in range(n_trials):
+        begin = time.time()
+        new_lines = RenameVariableJoernVersion(c_file).run()
+        end = time.time()
+        joern_times.append(end - begin)
+        assert count_diff(old_lines, new_lines) == (1, 1)
+        old_lines = new_lines
+
+    print(f'{sum(srcml_times)/len(srcml_times):.2f} SrcML {sum(joern_times)/len(joern_times):.2f} joern')
+
+
 def test_avoid():
     """Should avoid renaming x and instead rename y (second choice)."""
     c_file = Path(test_data_root/'testbed/testbed.c')

--- a/tests/test_refactorings.py
+++ b/tests/test_refactorings.py
@@ -24,6 +24,7 @@ def test_loop_exchange_unit(input_file, expected):
 
 @pytest.mark.parametrize("input_file,expected", [
     (test_data_root/'unit/switch_exchange.c', (7, 7)),
+    (test_data_root/'unit/switch_exchange_empty_block.c', (7, 7)),
     (test_data_root/'unit/switch_exchange_default_not_last.c', 'fallthrough'),
     (test_data_root/'unit/switch_exchange_fallthrough.c', 'expected tag to end block'),
     (test_data_root/'unit/switch_exchange_empty.c', 'empty switch statement'),

--- a/tests/test_refactorings.py
+++ b/tests/test_refactorings.py
@@ -101,6 +101,11 @@ def test_avoid():
     assert count_diff(old_lines, new_lines) == (7, 7)
 
 
+def test_insert_noop_targetcount():
+    c_file = Path(test_data_root/'testbed/testbed.c')
+    assert len(InsertNoop(c_file).get_targets()) == 32
+
+
 def test_insert_noop():
     c_file = Path(test_data_root/'testbed/testbed.c')
     with open(c_file) as f:

--- a/tests/test_refactorings.py
+++ b/tests/test_refactorings.py
@@ -62,36 +62,6 @@ def test_rename_variable():
     assert count_diff(old_lines, new_lines) == (5, 5)
 
 
-def test_joern_vs_srcml():
-    c_file = Path(test_data_root / 'timing/variables.c')
-    with open(c_file) as f:
-        old_lines = f.readlines()
-    import time
-    from refactorings.rename_variable_joern import RenameVariableJoernVersion
-
-    n_trials = 25
-
-    srcml_times = []
-    for i in range(n_trials):
-        begin = time.time()
-        new_lines = RenameVariable(c_file).run()
-        end = time.time()
-        srcml_times.append(end - begin)
-        assert count_diff(old_lines, new_lines) == (1, 1)
-        old_lines = new_lines
-
-    joern_times = []
-    for i in range(n_trials):
-        begin = time.time()
-        new_lines = RenameVariableJoernVersion(c_file).run()
-        end = time.time()
-        joern_times.append(end - begin)
-        assert count_diff(old_lines, new_lines) == (1, 1)
-        old_lines = new_lines
-
-    print(f'{sum(srcml_times)/len(srcml_times):.2f} SrcML {sum(joern_times)/len(joern_times):.2f} joern')
-
-
 def test_avoid():
     """Should avoid renaming x and instead rename y (second choice)."""
     c_file = Path(test_data_root/'testbed/testbed.c')

--- a/tests/test_refactorings.py
+++ b/tests/test_refactorings.py
@@ -8,18 +8,19 @@ from tests.test_utils import test_data_root, print_diff, count_diff
 
 
 @pytest.mark.parametrize("input_file,expected", [
-    (test_data_root/'unit/loop_exchange.c', (3, 1)),
-    (test_data_root/'unit/loop_exchange_no_init.c', (2, 1)),
-    (test_data_root/'unit/loop_exchange_no_cond.c', (3, 1)),
-    (test_data_root/'unit/loop_exchange_no_post.c', (2, 1)),
-    (test_data_root/'unit/loop_exchange_empty.c', (1, 1)),
+    (test_data_root/'unit/loop_exchange.c', (4, 2)),
+    (test_data_root/'unit/loop_exchange_no_init.c', (3, 2)),
+    (test_data_root/'unit/loop_exchange_no_cond.c', (4, 2)),
+    (test_data_root/'unit/loop_exchange_no_post.c', (3, 2)),
+    (test_data_root/'unit/loop_exchange_empty.c', (2, 2)),
 ])
 def test_loop_exchange_unit(input_file, expected):
     c_file = Path(input_file)
     with open(c_file) as f:
         old_lines = f.readlines()
     new_lines = LoopExchange(c_file).run()
-    assert count_diff(old_lines, new_lines) == expected, print_diff(old_lines, new_lines)
+    print_diff(old_lines, new_lines)
+    assert count_diff(old_lines, new_lines) == expected
 
 @pytest.mark.parametrize("input_file,expected", [
     (test_data_root/'unit/switch_exchange.c', (8, 8)),

--- a/tests/test_srcml.py
+++ b/tests/test_srcml.py
@@ -1,0 +1,21 @@
+from lxml import etree
+from srcml import SrcMLInfo
+
+
+def test_srcml_info():
+    c_code = '''int main()
+{
+    return 1;
+}
+'''
+    info = SrcMLInfo(c_code)
+    expected_xml_code = b'''
+'''
+    expected_xml_code = (b'''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<unit xmlns="http://www.srcML.org/srcML/src" revision="1.0.0" language="C"><function><type><name>int</name></type> <name>main</name><parameter_list>()</parameter_list>
+<block>{<block_content>
+    <return>return <expr><literal type="number">1</literal></expr>;</return>
+</block_content>}</block></function>
+</unit>
+''')
+    assert info.xml == expected_xml_code

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -1,0 +1,40 @@
+import time
+from pathlib import Path
+
+import pytest
+
+import refactorings
+from refactorings import RenameVariable, InsertNoop
+from refactorings.insert_noop_joern import InsertNoopJoernVersion
+from refactorings.rename_variable_joern import RenameVariableJoernVersion
+from tests.test_utils import test_data_root, count_diff
+
+
+@pytest.mark.parametrize("srcml_version,joern_version,filename", [
+    (RenameVariable, RenameVariableJoernVersion, 'timing/variables.c'),
+    (InsertNoop, InsertNoopJoernVersion, 'timing/noop.c'),
+])
+def test_joern_vs_srcml(srcml_version, joern_version, filename):
+    c_file = Path(test_data_root / filename)
+    n_trials = 10
+
+    srcml_times = []
+    for i in range(n_trials):
+        begin = time.time()
+        new_lines = srcml_version(c_file, picker=refactorings.random_picker).run()
+        end = time.time()
+        srcml_times.append(end - begin)
+        # assert count_diff(old_lines, new_lines) == (1, 1)
+        old_lines = new_lines
+
+    joern_times = []
+    for i in range(n_trials):
+        begin = time.time()
+        new_lines = joern_version(c_file, picker=refactorings.random_picker).run()
+        end = time.time()
+        joern_times.append(end - begin)
+        # assert count_diff(old_lines, new_lines) == (1, 1)
+        old_lines = new_lines
+
+    print(f'{srcml_version.__name__}:{sum(srcml_times)/len(srcml_times):.2f}s')
+    print(f'{joern_version.__name__}:{sum(joern_times)/len(joern_times):.2f}s')


### PR DESCRIPTION
SrcML parses about 10 times as fast as Joern because it doesn't require file I/O. For this reason, switch back to SrcML for all possible cases (cases that don't use CFG/DFG information).

Split into two base classes, `JoernTransformation` and `SrcMLTransformation` which are thin shims that provide their respective analysis frameworks.

SrcML is supposed to have some kind of support for control and data flow on the discord ([source](https://gitmemory.com/issue/srcML/srcML/1776/902895049)), but I'm waiting to be admitted before rolling my own for Permute Statement.